### PR TITLE
fix bug where first episode using Epsilon_Greedy_Exploration is random

### DIFF
--- a/exploration_strategies/Epsilon_Greedy_Exploration.py
+++ b/exploration_strategies/Epsilon_Greedy_Exploration.py
@@ -33,7 +33,7 @@ class Epsilon_Greedy_Exploration(Base_Exploration_Strategy):
         epsilon = self.get_updated_epsilon_exploration(action_info)
 
 
-        if (random.random() > epsilon or turn_off_exploration) and (episode_number > self.random_episodes_to_run):
+        if (random.random() > epsilon or turn_off_exploration) and (episode_number >= self.random_episodes_to_run):
             return torch.argmax(action_values).item()
         return random.randint(0, action_values.shape[1] - 1)
 


### PR DESCRIPTION
In `Epsilon_Greedy_Exploration.py`, `self.random_episodes_to_run` is set to zero by default. To check if our episode should be random, we need `episode_number >= self.random_episodes_to_run`, since `episode_number` is zero-indexed. (Instead of `episode_number >= self.random_episodes_to_run`.)