### PR TITLE
max_probability_action bugfix for batchsize > 1

### DIFF
--- a/agents/actor_critic_agents/SAC_Discrete.py
+++ b/agents/actor_critic_agents/SAC_Discrete.py
@@ -52,7 +52,7 @@ class SAC_Discrete(SAC):
         """Given the state, produces an action, the probability of the action, the log probability of the action, and
         the argmax action"""
         action_probabilities = self.actor_local(state)
-        max_probability_action = torch.argmax(action_probabilities).unsqueeze(0)
+        max_probability_action = torch.argmax(action_probabilities, dim=-1).unsqueeze(0)
         action_distribution = create_actor_distribution(self.action_types, action_probabilities, self.action_size)
         action = action_distribution.sample().cpu()
         # Have to deal with situation of 0.0 probabilities because we can't do log 0


### PR DESCRIPTION
When batch size is larger than 1, max_probability_action only returned a single action, often with a value larger than the action space.